### PR TITLE
Update .gitignore to work if imported as a submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.xcuserstate
 *.xcscheme
 *.xcbkptlist
+xcuserdata/
 BlueCap.xcodeproj/xcuserdata/*
 BlueCap.xcodeproj/project.xcworkspace/xcuserdata/*
 BlueCap.xcodeproj/project.xcworkspace/xcshareddata/*

--- a/BlueCapKit.xcodeproj/project.pbxproj
+++ b/BlueCapKit.xcodeproj/project.pbxproj
@@ -689,6 +689,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = BlueCapKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -706,6 +707,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = BlueCapKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
I've added a line so that the .gitignore works if you import BlueCap as a submodule.

Also, I've changed the deployment target to 8.2, which you may of course ignore. (There were a lot of bugfixes to the CB stack between 8.0 and 8.2, we've found it isn't worth chasing the ephemeral bugs in CB to support less than 1% of the market!)

Thanks for a great stack!