### PR TITLE
Fixes: retain cycles prevent CBPeripheral objects to be removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ BlueCap.xcodeproj/xcuserdata/*
 BlueCap.xcodeproj/project.xcworkspace/xcuserdata/*
 BlueCap.xcodeproj/project.xcworkspace/xcshareddata/*
 BlueCapKit.xcodeproj/project.xcworkspace/xcshareddata/*
+BlueCapKit.xcodeproj/xcuserdata/*
 .DS_Store

--- a/BlueCapKit/Central/CentralManager.swift
+++ b/BlueCapKit/Central/CentralManager.swift
@@ -129,6 +129,9 @@ public class CentralManager : NSObject, CBCentralManagerDelegate {
         if self._isScanning {
             self._isScanning = false
             self.cbCentralManager.stopScan()
+
+            // Reset the promise as it holds references to the CBPeripherals that are discovered
+            self.afterPeripheralDiscoveredPromise = StreamPromise<Peripheral>()
         }
     }
     

--- a/BlueCapKit/Central/TimedScannerator.swift
+++ b/BlueCapKit/Central/TimedScannerator.swift
@@ -51,8 +51,13 @@ public class TimedScannerator {
     internal func timeoutScan() {
         Logger.debug("timeout in \(self.timeoutSeconds)s")
         self.centralManager.centralQueue.delay(self.timeoutSeconds) {
-            if self.peripherals.count == 0 {
-                self.centralManager.afterPeripheralDiscoveredPromise.failure(BCError.peripheralDiscoveryTimeout)
+            if self._isScanning {
+                self.stopScanning()
+                
+                // Only call failure if it was stopped by timeout
+                if self.peripherals.count == 0 {
+                    self.centralManager.afterPeripheralDiscoveredPromise.failure(BCError.peripheralDiscoveryTimeout)
+                }
             }
         }
     }


### PR DESCRIPTION
This patches clear out the StreamPromise when the scanning is stopped. This allows the CBPeripheral to be correctly released.

It also force the scanning to be stopped after a timeout (which wasn't the case before) and make sure the timeout failure promise is called only if the scanning wasn't stopped before.

Should fix #16 