### PR TITLE
Handling Swift 2.2 deprecations

### DIFF
--- a/BlueCapKit/Central/Characteristic.swift
+++ b/BlueCapKit/Central/Characteristic.swift
@@ -439,7 +439,7 @@ public class Characteristic {
         self.writeParameters.removeAtIndex(0)
         self.writing = true
         self.writeValue(parameters.value, type:parameters.type)
-        ++self.writeSequence
+        self.writeSequence += 1
         self.timeoutWrite(self.writeSequence, timeout:parameters.timeout)
     }
     
@@ -451,7 +451,7 @@ public class Characteristic {
         self.readParameters.removeAtIndex(0)
         self.readValueForCharacteristic()
         self.reading = true
-        ++self.readSequence
+        self.readSequence += 1
         self.timeoutRead(self.readSequence, timeout:parameters.timeout)
     }
     

--- a/BlueCapKit/Central/Peripheral.swift
+++ b/BlueCapKit/Central/Peripheral.swift
@@ -194,7 +194,7 @@ public class Peripheral : NSObject, CBPeripheralDelegate {
             Logger.debug("reconnect peripheral \(self.name)")
             centralManager.connectPeripheral(self)
             self.forcedDisconnect = false
-            ++self.connectionSequence
+            self.connectionSequence += 1
             self.timeoutConnection(self.connectionSequence)
         }
     }
@@ -431,7 +431,7 @@ public class Peripheral : NSObject, CBPeripheralDelegate {
             self.connectionPromise?.failure(error)
             if let disconnectRetries = self.disconnectRetries {
                 if self.disconnectCount < disconnectRetries {
-                    ++self.disconnectCount
+                    self.disconnectCount += 1
                 } else {
                     self.disconnectCount = 0
                     self.connectionPromise?.success((self, ConnectionEvent.GiveUp))
@@ -448,7 +448,7 @@ public class Peripheral : NSObject, CBPeripheralDelegate {
         if let timeoutRetries = self.timeoutRetries {
             if self.timeoutCount < timeoutRetries {
                 self.connectionPromise?.success((self, ConnectionEvent.Timeout))
-                ++self.timeoutCount
+                self.timeoutCount += 1
             } else {
                 self.timeoutCount = 0
                 self.connectionPromise?.success((self, ConnectionEvent.GiveUp))
@@ -462,7 +462,7 @@ public class Peripheral : NSObject, CBPeripheralDelegate {
         Logger.debug()
         if let disconnectRetries = self.disconnectRetries {
             if self.disconnectCount < disconnectRetries {
-                ++self.disconnectCount
+                self.disconnectCount += 1
                 self.connectionPromise?.success((self, ConnectionEvent.Disconnect))
             } else {
                 self.disconnectCount = 0


### PR DESCRIPTION
Xcode 7.3 beta 2 contains Swift 2.2, which is part of Swift's migration for 3.0 deprecations and removals. (More info in the [Xcode 7.3 release notes](https://developer.apple.com/go/?id=xcode-7.3-rn)).

Here's most (but not all of) the deprecation warnings from Swift 2.2.