### PR TITLE
 More Swift 2.2 deprecations

### DIFF
--- a/BlueCapKit/Extensions/StringExtensions.swift
+++ b/BlueCapKit/Extensions/StringExtensions.swift
@@ -17,7 +17,8 @@ public extension String {
     public func dataFromHexString() -> NSData {
         var bytes = [UInt8]()
         for i in 0..<(self.characters.count/2) {
-            let stringBytes = self.substringWithRange(Range(start:self.startIndex.advancedBy(2*i), end:self.startIndex.advancedBy(2*i+2)))
+            let range = self.startIndex.advancedBy(2*i)..<self.startIndex.advancedBy(2*i+2)
+            let stringBytes = self.substringWithRange(range)
             let byte = strtol((stringBytes as NSString).UTF8String, nil, 16)
             bytes.append(UInt8(byte))
         }

--- a/BlueCapKit/External/FutureLocation/FLLogger.swift
+++ b/BlueCapKit/External/FutureLocation/FLLogger.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public class FLLogger {
-    public class func debug(message:String? = nil, function: String = __FUNCTION__, file: String = __FILE__, line: Int = __LINE__) {
+    public class func debug(message:String? = nil, function: String = #function, file: String = #file, line: Int = #line) {
 #if DEBUG
         if let message = message {
             print("\(file):\(function):\(line): \(message)")

--- a/BlueCapKit/SerDe/BCSerDe.swift
+++ b/BlueCapKit/SerDe/BCSerDe.swift
@@ -70,14 +70,14 @@ public protocol BCStringDeserializable {
 }
 
 public protocol BCRawDeserializable {
-    typealias RawType
+    associatedtype RawType
     static var UUID         : String {get}
     var rawValue            : RawType {get}
     init?(rawValue:RawType)
 }
 
 public protocol BCRawArrayDeserializable {
-    typealias RawType
+    associatedtype RawType
     static var UUID     : String {get}
     static var size     : Int {get}
     var rawValue        : [RawType] {get}
@@ -85,8 +85,8 @@ public protocol BCRawArrayDeserializable {
 }
 
 public protocol BCRawPairDeserializable {
-    typealias RawType1
-    typealias RawType2
+    associatedtype RawType1
+    associatedtype RawType2
     static var UUID     : String {get}
     var rawValue1       : RawType1 {get}
     var rawValue2       : RawType2 {get}
@@ -94,8 +94,8 @@ public protocol BCRawPairDeserializable {
 }
 
 public protocol BCRawArrayPairDeserializable {
-    typealias RawType1
-    typealias RawType2
+    associatedtype RawType1
+    associatedtype RawType2
     static var UUID     : String {get}
     static var size1    : Int {get}
     static var size2    : Int {get}

--- a/BlueCapKit/Utilities/BCLogger.swift
+++ b/BlueCapKit/Utilities/BCLogger.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public class BCLogger {
-    public class func debug(message:String? = nil, function: String = __FUNCTION__, file: String = __FILE__, line: Int = __LINE__) {
+    public class func debug(message:String? = nil, function: String = #function, file: String = #file, line: Int = #line) {
 #if DEBUG
         if let message = message {
             print("\(file):\(function):\(line): \(message)")


### PR DESCRIPTION
Two commits for more deprecations from Xcode 7.3 beta 4.

The first one was easy, it's just fixits. Please review the second to make sure it's correct.