### PR TITLE
Add tvOS Support

### DIFF
--- a/BlueCapKit.podspec
+++ b/BlueCapKit.podspec
@@ -11,12 +11,16 @@ Pod::Spec.new do |spec|
   spec.author             = { "Troy Stribling" => "me@troystribling.com" }
   spec.social_media_url   = "http://twitter.com/troystribling"
 
-  spec.platform           = :ios, "9.0"
+  spec.ios.deployment_target = "9.0"
+  spec.tvos.deployment_target = "9.0"
 
   spec.cocoapods_version  = '>= 1.1'
 
   spec.source             = { :git => "https://github.com/troystribling/BlueCap.git", :tag => "#{spec.version}" }
-  spec.source_files       = "BlueCapKit/**/*.swift"
-  spec.frameworks         = "CoreBluetooth", "CoreLocation"
+  spec.ios.source_files   = "BlueCapKit/**/*.swift"
+  spec.tvos.source_files  = "BlueCapKit/**/*.swift"
+  spec.tvos.exclude_files = "BlueCapKit/External/FutureLocation/**/*.swift"
+  spec.ios.frameworks     = "CoreBluetooth", "CoreLocation"
+  spec.tvos.frameworks    = "CoreBluetooth"
 
 end

--- a/BlueCapKit.xcodeproj/project.pbxproj
+++ b/BlueCapKit.xcodeproj/project.pbxproj
@@ -46,6 +46,36 @@
 		05D3B9461A2BA162008E794E /* String+BlueCap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D3B9441A2BA162008E794E /* String+BlueCap.swift */; };
 		05FC0A0F1CC7CF5E0071BC8F /* Injectables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05FC0A0E1CC7CF5E0071BC8F /* Injectables.swift */; };
 		4ED105C01C315C420034D5D2 /* UInt32+Deserializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED105BF1C315C420034D5D2 /* UInt32+Deserializable.swift */; };
+		82F970AE1E30D40400DCF557 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82F970AD1E30D40400DCF557 /* CoreBluetooth.framework */; };
+		82F970B31E30E44500DCF557 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05585BE21D0CA4AB000F5307 /* Logger.swift */; };
+		82F970B41E30E45700DCF557 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 056276081CCD3F0A00F955D7 /* Errors.swift */; };
+		82F970B51E30E45700DCF557 /* Injectables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05FC0A0E1CC7CF5E0071BC8F /* Injectables.swift */; };
+		82F970B61E30E45700DCF557 /* CentralManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05585BCA1D0CA437000F5307 /* CentralManager.swift */; };
+		82F970B71E30E45700DCF557 /* Characteristic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05585BCB1D0CA437000F5307 /* Characteristic.swift */; };
+		82F970B81E30E45700DCF557 /* Peripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05585BCC1D0CA437000F5307 /* Peripheral.swift */; };
+		82F970B91E30E45700DCF557 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05585BCD1D0CA437000F5307 /* Service.swift */; };
+		82F970BA1E30E45700DCF557 /* Double+BlueCap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D3B9431A2BA162008E794E /* Double+BlueCap.swift */; };
+		82F970BB1E30E45700DCF557 /* String+BlueCap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D3B9441A2BA162008E794E /* String+BlueCap.swift */; };
+		82F970C41E30E45700DCF557 /* SimpleFutures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05BF91A21CFBF62700B78B12 /* SimpleFutures.swift */; };
+		82F970C51E30E45700DCF557 /* MutableCharacteristic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C405991D7B7BF900803654 /* MutableCharacteristic.swift */; };
+		82F970C61E30E45700DCF557 /* MutableService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C4059A1D7B7BF900803654 /* MutableService.swift */; };
+		82F970C71E30E45700DCF557 /* PeripheralManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C4059B1D7B7BF900803654 /* PeripheralManager.swift */; };
+		82F970C81E30E45700DCF557 /* Data+Serializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C405961D7B7BE300803654 /* Data+Serializable.swift */; };
+		82F970C91E30E45700DCF557 /* SerDe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05585BDA1D0CA459000F5307 /* SerDe.swift */; };
+		82F970CA1E30E45700DCF557 /* Int8+Deserializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055120B419F5513700ED3B74 /* Int8+Deserializable.swift */; };
+		82F970CB1E30E45700DCF557 /* Int16+Deserializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055120B319F5513700ED3B74 /* Int16+Deserializable.swift */; };
+		82F970CC1E30E45700DCF557 /* Uint8+Deserializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055120B819F5513700ED3B74 /* Uint8+Deserializable.swift */; };
+		82F970CD1E30E45700DCF557 /* UInt16+Deserializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055120B719F5513700ED3B74 /* UInt16+Deserializable.swift */; };
+		82F970CE1E30E45700DCF557 /* UInt32+Deserializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED105BF1C315C420034D5D2 /* UInt32+Deserializable.swift */; };
+		82F970CF1E30E45700DCF557 /* Int32+Deserializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 057FACEF1D1C325B0006B93B /* Int32+Deserializable.swift */; };
+		82F970D01E30E45700DCF557 /* TiSensorTagProfiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05AFDBEB1E082FB700AA92E7 /* TiSensorTagProfiles.swift */; };
+		82F970D11E30E45700DCF557 /* BLESIGGATTProfiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055120C319F5513700ED3B74 /* BLESIGGATTProfiles.swift */; };
+		82F970D21E30E45700DCF557 /* GnosusProfiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055120C419F5513700ED3B74 /* GnosusProfiles.swift */; };
+		82F970D31E30E45700DCF557 /* NordicProfiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055120C519F5513700ED3B74 /* NordicProfiles.swift */; };
+		82F970D41E30E45700DCF557 /* ServiceProfileUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055120C619F5513700ED3B74 /* ServiceProfileUtils.swift */; };
+		82F970D51E30E45700DCF557 /* CharacteristicProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05585BDC1D0CA475000F5307 /* CharacteristicProfile.swift */; };
+		82F970D61E30E45700DCF557 /* ProfileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05585BDD1D0CA475000F5307 /* ProfileManager.swift */; };
+		82F970D71E30E45700DCF557 /* ServiceProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05585BDE1D0CA475000F5307 /* ServiceProfile.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -90,6 +120,9 @@
 		05D3B9441A2BA162008E794E /* String+BlueCap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+BlueCap.swift"; sourceTree = "<group>"; };
 		05FC0A0E1CC7CF5E0071BC8F /* Injectables.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Injectables.swift; sourceTree = "<group>"; };
 		4ED105BF1C315C420034D5D2 /* UInt32+Deserializable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UInt32+Deserializable.swift"; sourceTree = "<group>"; };
+		82F970A41E30D39A00DCF557 /* BlueCapKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BlueCapKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		82F970AD1E30D40400DCF557 /* CoreBluetooth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreBluetooth.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS10.1.sdk/System/Library/Frameworks/CoreBluetooth.framework; sourceTree = DEVELOPER_DIR; };
+		82F970AF1E30D40A00DCF557 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS10.1.sdk/System/Library/Frameworks/CoreLocation.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -102,16 +135,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		82F970A01E30D39A00DCF557 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				82F970AE1E30D40400DCF557 /* CoreBluetooth.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		0551207819F5506000ED3B74 = {
 			isa = PBXGroup;
 			children = (
-				055120F719F551CB00ED3B74 /* CoreBluetooth.framework */,
-				055120F519F551BB00ED3B74 /* CoreLocation.framework */,
 				0551208419F5506000ED3B74 /* BlueCapKit */,
 				0551208319F5506000ED3B74 /* Products */,
+				82F970AC1E30D40400DCF557 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -119,6 +159,7 @@
 			isa = PBXGroup;
 			children = (
 				0551208219F5506000ED3B74 /* BlueCapKit.framework */,
+				82F970A41E30D39A00DCF557 /* BlueCapKit.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -256,6 +297,33 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		82F970AC1E30D40400DCF557 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				82F970B11E30D41D00DCF557 /* iOS */,
+				82F970B21E30D42000DCF557 /* tvOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		82F970B11E30D41D00DCF557 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				055120F719F551CB00ED3B74 /* CoreBluetooth.framework */,
+				055120F519F551BB00ED3B74 /* CoreLocation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		82F970B21E30D42000DCF557 /* tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				82F970AF1E30D40A00DCF557 /* CoreLocation.framework */,
+				82F970AD1E30D40400DCF557 /* CoreBluetooth.framework */,
+			);
+			name = tvOS;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -266,12 +334,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		82F970A11E30D39A00DCF557 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		0551208119F5506000ED3B74 /* BlueCapKit */ = {
+		0551208119F5506000ED3B74 /* BlueCapKit iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 0551209519F5506000ED3B74 /* Build configuration list for PBXNativeTarget "BlueCapKit" */;
+			buildConfigurationList = 0551209519F5506000ED3B74 /* Build configuration list for PBXNativeTarget "BlueCapKit iOS" */;
 			buildPhases = (
 				0551207D19F5506000ED3B74 /* Sources */,
 				0551207E19F5506000ED3B74 /* Frameworks */,
@@ -282,9 +357,27 @@
 			);
 			dependencies = (
 			);
-			name = BlueCapKit;
+			name = "BlueCapKit iOS";
 			productName = BlueCapKit;
 			productReference = 0551208219F5506000ED3B74 /* BlueCapKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		82F970A31E30D39A00DCF557 /* BlueCapKit tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 82F970AB1E30D39A00DCF557 /* Build configuration list for PBXNativeTarget "BlueCapKit tvOS" */;
+			buildPhases = (
+				82F9709F1E30D39A00DCF557 /* Sources */,
+				82F970A01E30D39A00DCF557 /* Frameworks */,
+				82F970A11E30D39A00DCF557 /* Headers */,
+				82F970A21E30D39A00DCF557 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "BlueCapKit tvOS";
+			productName = "BlueCapKit tvOS";
+			productReference = 82F970A41E30D39A00DCF557 /* BlueCapKit.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -302,6 +395,10 @@
 						DevelopmentTeam = HZEX459C37;
 						LastSwiftMigration = 0800;
 					};
+					82F970A31E30D39A00DCF557 = {
+						CreatedOnToolsVersion = 8.2.1;
+						ProvisioningStyle = Manual;
+					};
 				};
 			};
 			buildConfigurationList = 0551207C19F5506000ED3B74 /* Build configuration list for PBXProject "BlueCapKit" */;
@@ -316,13 +413,21 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				0551208119F5506000ED3B74 /* BlueCapKit */,
+				0551208119F5506000ED3B74 /* BlueCapKit iOS */,
+				82F970A31E30D39A00DCF557 /* BlueCapKit tvOS */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		0551208019F5506000ED3B74 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		82F970A21E30D39A00DCF557 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -373,6 +478,42 @@
 				05C4059C1D7B7BF900803654 /* MutableCharacteristic.swift in Sources */,
 				05BF91A31CFBF62700B78B12 /* CLProximityExtension.swift in Sources */,
 				05585BE01D0CA475000F5307 /* ProfileManager.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		82F9709F1E30D39A00DCF557 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				82F970B51E30E45700DCF557 /* Injectables.swift in Sources */,
+				82F970C81E30E45700DCF557 /* Data+Serializable.swift in Sources */,
+				82F970D41E30E45700DCF557 /* ServiceProfileUtils.swift in Sources */,
+				82F970BA1E30E45700DCF557 /* Double+BlueCap.swift in Sources */,
+				82F970D31E30E45700DCF557 /* NordicProfiles.swift in Sources */,
+				82F970D61E30E45700DCF557 /* ProfileManager.swift in Sources */,
+				82F970BB1E30E45700DCF557 /* String+BlueCap.swift in Sources */,
+				82F970CE1E30E45700DCF557 /* UInt32+Deserializable.swift in Sources */,
+				82F970D51E30E45700DCF557 /* CharacteristicProfile.swift in Sources */,
+				82F970B91E30E45700DCF557 /* Service.swift in Sources */,
+				82F970B81E30E45700DCF557 /* Peripheral.swift in Sources */,
+				82F970D71E30E45700DCF557 /* ServiceProfile.swift in Sources */,
+				82F970CD1E30E45700DCF557 /* UInt16+Deserializable.swift in Sources */,
+				82F970D01E30E45700DCF557 /* TiSensorTagProfiles.swift in Sources */,
+				82F970B41E30E45700DCF557 /* Errors.swift in Sources */,
+				82F970B71E30E45700DCF557 /* Characteristic.swift in Sources */,
+				82F970CF1E30E45700DCF557 /* Int32+Deserializable.swift in Sources */,
+				82F970C71E30E45700DCF557 /* PeripheralManager.swift in Sources */,
+				82F970D21E30E45700DCF557 /* GnosusProfiles.swift in Sources */,
+				82F970C91E30E45700DCF557 /* SerDe.swift in Sources */,
+				82F970D11E30E45700DCF557 /* BLESIGGATTProfiles.swift in Sources */,
+				82F970B31E30E44500DCF557 /* Logger.swift in Sources */,
+				82F970C61E30E45700DCF557 /* MutableService.swift in Sources */,
+				82F970CA1E30E45700DCF557 /* Int8+Deserializable.swift in Sources */,
+				82F970C51E30E45700DCF557 /* MutableCharacteristic.swift in Sources */,
+				82F970C41E30E45700DCF557 /* SimpleFutures.swift in Sources */,
+				82F970CC1E30E45700DCF557 /* Uint8+Deserializable.swift in Sources */,
+				82F970CB1E30E45700DCF557 /* Int16+Deserializable.swift in Sources */,
+				82F970B61E30E45700DCF557 /* CentralManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -487,8 +628,8 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_CFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = "us.gnos.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = us.gnos.BlueCapKit;
+				PRODUCT_NAME = BlueCapKit;
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;
@@ -508,11 +649,63 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_CFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = "us.gnos.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = us.gnos.BlueCapKit;
+				PRODUCT_NAME = BlueCapKit;
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+		82F970A91E30D39A00DCF557 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/BlueCapKit/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = us.gnos.BlueCapKit;
+				PRODUCT_NAME = BlueCapKit;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		82F970AA1E30D39A00DCF557 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/BlueCapKit/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = us.gnos.BlueCapKit;
+				PRODUCT_NAME = BlueCapKit;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};
@@ -528,7 +721,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		0551209519F5506000ED3B74 /* Build configuration list for PBXNativeTarget "BlueCapKit" */ = {
+		0551209519F5506000ED3B74 /* Build configuration list for PBXNativeTarget "BlueCapKit iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				0551209619F5506000ED3B74 /* Debug */,
@@ -536,6 +729,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		82F970AB1E30D39A00DCF557 /* Build configuration list for PBXNativeTarget "BlueCapKit tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				82F970A91E30D39A00DCF557 /* Debug */,
+				82F970AA1E30D39A00DCF557 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/BlueCapKit.xcodeproj/xcshareddata/xcschemes/BlueCapKit iOS.xcscheme
+++ b/BlueCapKit.xcodeproj/xcshareddata/xcschemes/BlueCapKit iOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0810"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0551208119F5506000ED3B74"
+               BuildableName = "BlueCapKit iOS.framework"
+               BlueprintName = "BlueCapKit iOS"
+               ReferencedContainer = "container:BlueCapKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0551208C19F5506000ED3B74"
+               BuildableName = "BlueCapKitTests.xctest"
+               BlueprintName = "BlueCapKitTests"
+               ReferencedContainer = "container:BlueCapKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0551208119F5506000ED3B74"
+            BuildableName = "BlueCapKit iOS.framework"
+            BlueprintName = "BlueCapKit iOS"
+            ReferencedContainer = "container:BlueCapKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0551208119F5506000ED3B74"
+            BuildableName = "BlueCapKit iOS.framework"
+            BlueprintName = "BlueCapKit iOS"
+            ReferencedContainer = "container:BlueCapKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0551208119F5506000ED3B74"
+            BuildableName = "BlueCapKit iOS.framework"
+            BlueprintName = "BlueCapKit iOS"
+            ReferencedContainer = "container:BlueCapKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BlueCapKit.xcodeproj/xcshareddata/xcschemes/BlueCapKit tvOS.xcscheme
+++ b/BlueCapKit.xcodeproj/xcshareddata/xcschemes/BlueCapKit tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0810"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0551208119F5506000ED3B74"
-               BuildableName = "BlueCapKit.framework"
-               BlueprintName = "BlueCapKit"
+               BlueprintIdentifier = "82F970A31E30D39A00DCF557"
+               BuildableName = "BlueCapKit tvOS.framework"
+               BlueprintName = "BlueCapKit tvOS"
                ReferencedContainer = "container:BlueCapKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,26 +28,7 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0551208C19F5506000ED3B74"
-               BuildableName = "BlueCapKitTests.xctest"
-               BlueprintName = "BlueCapKitTests"
-               ReferencedContainer = "container:BlueCapKit.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "0551208119F5506000ED3B74"
-            BuildableName = "BlueCapKit.framework"
-            BlueprintName = "BlueCapKit"
-            ReferencedContainer = "container:BlueCapKit.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -64,9 +45,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "0551208119F5506000ED3B74"
-            BuildableName = "BlueCapKit.framework"
-            BlueprintName = "BlueCapKit"
+            BlueprintIdentifier = "82F970A31E30D39A00DCF557"
+            BuildableName = "BlueCapKit tvOS.framework"
+            BlueprintName = "BlueCapKit tvOS"
             ReferencedContainer = "container:BlueCapKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -82,9 +63,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "0551208119F5506000ED3B74"
-            BuildableName = "BlueCapKit.framework"
-            BlueprintName = "BlueCapKit"
+            BlueprintIdentifier = "82F970A31E30D39A00DCF557"
+            BuildableName = "BlueCapKit tvOS.framework"
+            BlueprintName = "BlueCapKit tvOS"
             ReferencedContainer = "container:BlueCapKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/BlueCapKit/Info.plist
+++ b/BlueCapKit/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.0</string>
+	<string>0.4.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/BlueCapKit/PeripheralManager/MutableCharacteristic.swift
+++ b/BlueCapKit/PeripheralManager/MutableCharacteristic.swift
@@ -95,10 +95,12 @@ public class MutableCharacteristic : NSObject {
 
     // MARK: Initializers
 
-    public convenience init(profile: CharacteristicProfile) {
-        let cbMutableChracteristic = CBMutableCharacteristic(type: profile.uuid, properties: profile.properties, value: nil, permissions: profile.permissions)
-        self.init(cbMutableCharacteristic: cbMutableChracteristic, profile: profile)
-    }
+    #if os(iOS)
+        public convenience init(profile: CharacteristicProfile) {
+            let cbMutableChracteristic = CBMutableCharacteristic(type: profile.uuid, properties: profile.properties, value: nil, permissions: profile.permissions)
+            self.init(cbMutableCharacteristic: cbMutableChracteristic, profile: profile)
+        }
+    #endif
 
     internal init(cbMutableCharacteristic: CBMutableCharacteristicInjectable, profile: CharacteristicProfile) {
         self.profile = profile
@@ -112,23 +114,25 @@ public class MutableCharacteristic : NSObject {
         self.cbMutableChracteristic = cbMutableCharacteristic
     }
 
-    public init(UUID: String, properties: CBCharacteristicProperties, permissions: CBAttributePermissions, value: Data?) {
-        self.profile = CharacteristicProfile(uuid: UUID)
-        self._value = value
-        self.cbMutableChracteristic = CBMutableCharacteristic(type:self.profile.uuid, properties:properties, value:nil, permissions:permissions)
-    }
+    #if os(iOS)
+        public init(UUID: String, properties: CBCharacteristicProperties, permissions: CBAttributePermissions, value: Data?) {
+            self.profile = CharacteristicProfile(uuid: UUID)
+            self._value = value
+            self.cbMutableChracteristic = CBMutableCharacteristic(type:self.profile.uuid, properties:properties, value:nil, permissions:permissions)
+        }
 
-    public convenience init(UUID: String) {
-        self.init(profile: CharacteristicProfile(uuid: UUID))
-    }
+        public convenience init(UUID: String) {
+            self.init(profile: CharacteristicProfile(uuid: UUID))
+        }
 
-    public class func withProfiles(_ profiles: [CharacteristicProfile]) -> [MutableCharacteristic] {
-        return profiles.map{ MutableCharacteristic(profile: $0) }
-    }
+        public class func withProfiles(_ profiles: [CharacteristicProfile]) -> [MutableCharacteristic] {
+            return profiles.map{ MutableCharacteristic(profile: $0) }
+        }
 
-    public class func withProfiles(_ profiles: [CharacteristicProfile], cbCharacteristics: [CBMutableCharacteristic]) -> [MutableCharacteristic] {
-        return profiles.map{ MutableCharacteristic(profile: $0) }
-    }
+        public class func withProfiles(_ profiles: [CharacteristicProfile], cbCharacteristics: [CBMutableCharacteristic]) -> [MutableCharacteristic] {
+            return profiles.map{ MutableCharacteristic(profile: $0) }
+        }
+    #endif
 
     // MARK: Properties & Permissions
 

--- a/BlueCapKit/PeripheralManager/MutableService.swift
+++ b/BlueCapKit/PeripheralManager/MutableService.swift
@@ -35,14 +35,17 @@ public class MutableService : NSObject {
             self.cbMutableService.setCharacteristics(cbCharacteristics)
         }
     }
-    
-    public convenience init(profile: ServiceProfile) {
-        self.init(cbMutableService: CBMutableService(type: profile.uuid, primary: true), profile: profile)
-    }
 
-    public convenience init(uuid: String) {
-        self.init(profile: ServiceProfile(uuid: uuid))
-    }
+    #if os(iOS)
+        public convenience init(profile: ServiceProfile) {
+            self.init(cbMutableService: CBMutableService(type: profile.uuid, primary: true), profile: profile)
+        }
+
+
+        public convenience init(uuid: String) {
+            self.init(profile: ServiceProfile(uuid: uuid))
+        }
+    #endif
 
     internal init(cbMutableService: CBMutableServiceInjectable, profile: ServiceProfile? = nil) {
         self.cbMutableService = cbMutableService
@@ -50,8 +53,10 @@ public class MutableService : NSObject {
         super.init()
     }
 
-    public func characteristicsFromProfiles() {
-        self.characteristics = self.profile.characteristics.map { MutableCharacteristic(profile: $0) }
-    }
+    #if os(iOS)
+        public func characteristicsFromProfiles() {
+            self.characteristics = self.profile.characteristics.map { MutableCharacteristic(profile: $0) }
+        }
+    #endif
     
 }

--- a/BlueCapKit/PeripheralManager/PeripheralManager.swift
+++ b/BlueCapKit/PeripheralManager/PeripheralManager.swift
@@ -150,24 +150,26 @@ public class PeripheralManager: NSObject, CBPeripheralManagerDelegate {
             }
         }
     }
-    
-    public func startAdvertising(_ region: BeaconRegion) -> Future<Void> {
-        return self.peripheralQueue.sync {
-            if let afterBeaconAdvertisingStartedPromise = self.afterBeaconAdvertisingStartedPromise, !afterBeaconAdvertisingStartedPromise.completed {
-                Logger.debug("Alerady adversting beacon")
-                return afterBeaconAdvertisingStartedPromise.future
-            }
-            Logger.debug("Adversting beacon with UUID: \(region.proximityUUID)")
-            self._name = region.identifier
-            self.afterBeaconAdvertisingStartedPromise = Promise<Void>()
-            if !self.isAdvertising {
-                self.cbPeripheralManager.startAdvertising(region.peripheralDataWithMeasuredPower(nil))
-                return self.afterBeaconAdvertisingStartedPromise!.future
-            } else {
-                return Future(error: PeripheralManagerError.isAdvertising)
+
+    #if os(iOS)
+        public func startAdvertising(_ region: BeaconRegion) -> Future<Void> {
+            return self.peripheralQueue.sync {
+                if let afterBeaconAdvertisingStartedPromise = self.afterBeaconAdvertisingStartedPromise, !afterBeaconAdvertisingStartedPromise.completed {
+                    Logger.debug("Alerady adversting beacon")
+                    return afterBeaconAdvertisingStartedPromise.future
+                }
+                Logger.debug("Adversting beacon with UUID: \(region.proximityUUID)")
+                self._name = region.identifier
+                self.afterBeaconAdvertisingStartedPromise = Promise<Void>()
+                if !self.isAdvertising {
+                    self.cbPeripheralManager.startAdvertising(region.peripheralDataWithMeasuredPower(nil))
+                    return self.afterBeaconAdvertisingStartedPromise!.future
+                } else {
+                    return Future(error: PeripheralManagerError.isAdvertising)
+                }
             }
         }
-    }
+    #endif
     
     public func stopAdvertising(timeout: TimeInterval = 10.0) -> Future<Void> {
         return self.peripheralQueue.sync {

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ BlueCap provides a swift wrapper around CoreBluetooth and much more.
 # Features
 
 - A [futures](https://github.com/troystribling/SimpleFutures) interface replacing protocol implementations.
-- Timeout for `Peripheral` connection, `Service` scan, 'Service` and `Characteristic` discovery and `Characteristic` read/write.
+- Timeout for `Peripheral` connection, `Service` scan, `Service` and `Characteristic` discovery and `Characteristic` read/write.
 - A DSL for specification of GATT profiles.
 - Characteristic profile types encapsulating serialization and deserialization.
 - [Example](/Examples) applications implementing CentralManager and PeripheralManager.
@@ -62,7 +62,7 @@ brew install carthage
 To add `BlueCapKit` to your `Cartfile`
 
 ```ogdl
-github "troystribling/BlueCap" ~> 0.2
+github "troystribling/BlueCap" ~> 0.4
 ```
 
 To download and build `BlueCapKit.framework` run the command,

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ BlueCap provides a swift wrapper around CoreBluetooth and much more.
 
 # Requirements
 
-- iOS 9.0+
+- iOS 9.0+ / tvOS 9.0+
 - Xcode 8.2
 
 # Installation


### PR DESCRIPTION
This attempts to solve #51.

Specifically the steps done are:
- [x] Add new target for tvOS
- [x] Rename iOS target to include the platform
- [x] Add all parts of code that are available via tvOS APIs, which means:
  - [x] Removed the location feature (as CoreLocation doesn't provide APIs for it)
  - [x] Removed some peripheral-related initializers (see also [this thread](http://stackoverflow.com/questions/33476994/defining-custom-services-and-characteristics-on-tvos) on SO)
- [x] Add tvOS-support in `.podspec` for Cocoapods support (`pod lib lint` passed)
- [x] Shared tvOS scheme for Carthage support
- [x] List tvOS as an alternative to iOS in requirements section within README

**Everything should behave as before regarding iOS** – the target name change shouldn't affect the framework name as I changed it not to rely on the target name (otherwise the iOS framework would have a differing name from the tvOS framework, which is usually not the expected behavior).