### PR TITLE
Bluetooth Restoration bug fix

### DIFF
--- a/BlueCapKit/Central/CentralManager.swift
+++ b/BlueCapKit/Central/CentralManager.swift
@@ -138,7 +138,7 @@ public class CentralManager : NSObject, CBCentralManagerDelegate {
     func connect(_ cbPeripheral: CBPeripheralInjectable, options: [String : Any]? = nil) {
         cbCentralManager.connect(cbPeripheral, options: options)
     }
-    
+
     func cancelPeripheralConnection(_ cbPeripheral: CBPeripheralInjectable) {
         cbCentralManager.cancelPeripheralConnection(cbPeripheral)
     }
@@ -190,7 +190,7 @@ public class CentralManager : NSObject, CBCentralManagerDelegate {
             return self.afterPeripheralDiscoveredPromise!.stream
         }
     }
-    
+
     public func stopScanning() {
         self.centralQueue.sync {
             self.stopScanningIfScanning()
@@ -293,30 +293,30 @@ public class CentralManager : NSObject, CBCentralManagerDelegate {
             injectablePeripherals = cbPeripherals.map { $0 as CBPeripheralInjectable }
         }
         let scannedServices = dict[CBCentralManagerRestoredStateScanServicesKey] as? [CBUUID]
-        let options = dict[CBCentralManagerRestoredStateScanOptionsKey] as? [String: AnyObject]
-        willRestoreState(injectablePeripherals, scannedServices: scannedServices, options: options)
+        let scanOptions = dict[CBCentralManagerRestoredStateScanOptionsKey] as? [String: AnyObject]
+        willRestoreState(injectablePeripherals, scannedServices: scannedServices, scanOptions: scanOptions)
     }
-    
+
     public func centralManagerDidUpdateState(_ central: CBCentralManager) {
         didUpdateState(central)
     }
 
     // MARK: CBCentralManagerDelegate Shims
-    
+
     func didConnectPeripheral(_ peripheral: CBPeripheralInjectable) {
         Logger.debug("'\(name)' uuid=\(peripheral.identifier.uuidString), name=\(String(describing: peripheral.name))")
         if let bcPeripheral = _discoveredPeripherals[peripheral.identifier] {
             bcPeripheral.didConnectPeripheral()
         }
     }
-    
+
     func didDisconnectPeripheral(_ peripheral: CBPeripheralInjectable, error: Error?) {
         Logger.debug("\(name) uuid=\(peripheral.identifier.uuidString), name=\(String(describing: peripheral.name)), error=\(String(describing: error))")
         if let bcPeripheral = _discoveredPeripherals[peripheral.identifier] {
             bcPeripheral.didDisconnectPeripheral(error)
         }
     }
-    
+
     func didDiscoverPeripheral(_ peripheral: CBPeripheralInjectable, advertisementData: [String : Any], RSSI: NSNumber) {
         var bcPeripheral: Peripheral
         if let discoveredPeripheral = _discoveredPeripherals[peripheral.identifier] {
@@ -334,7 +334,7 @@ public class CentralManager : NSObject, CBCentralManagerDelegate {
         }
         Logger.debug("'\(name)' uuid=\(bcPeripheral.identifier.uuidString), name=\(bcPeripheral.name), RSSI=\(RSSI), Advertisements=\(advertisementData)")
     }
-    
+
     func didFailToConnectPeripheral(_ peripheral: CBPeripheralInjectable, error: Error?) {
         Logger.debug("'\(name)'")
         guard let bcPeripheral = _discoveredPeripherals[peripheral.identifier] else {
@@ -343,10 +343,14 @@ public class CentralManager : NSObject, CBCentralManagerDelegate {
         bcPeripheral.didFailToConnectPeripheral(error)
     }
 
-    func willRestoreState(_ cbPeripherals: [CBPeripheralInjectable]?, scannedServices: [CBUUID]?, options: [String: AnyObject]?) {
+
+
+    func willRestoreState(_ cbPeripherals: [CBPeripheralInjectable]?, scannedServices: [CBUUID]?, scanOptions: [String: AnyObject]?) {
         Logger.debug("'\(name)'")
-        if let cbPeripherals = cbPeripherals, let options = options {
-            self.options = options
+        if let cbPeripherals = cbPeripherals {
+            if let options = scanOptions {
+                self.options = options
+            }
             cbPeripherals.forEach { cbPeripheral in
                 let peripheral = Peripheral(cbPeripheral: cbPeripheral, centralManager: self)
                 _discoveredPeripherals[cbPeripheral.identifier] = peripheral
@@ -385,5 +389,6 @@ public class CentralManager : NSObject, CBCentralManagerDelegate {
         Logger.debug("'\(name)' did update state '\(centralManager.managerState)'")
         afterStateChangedPromise?.success(centralManager.managerState)
     }
-    
+
 }
+

--- a/BlueCapKit/Central/CentralManager.swift
+++ b/BlueCapKit/Central/CentralManager.swift
@@ -293,7 +293,7 @@ public class CentralManager : NSObject, CBCentralManagerDelegate {
             injectablePeripherals = cbPeripherals.map { $0 as CBPeripheralInjectable }
         }
         let scannedServices = dict[CBCentralManagerRestoredStateScanServicesKey] as? [CBUUID]
-        let scanOptions = dict[CBCentralManagerRestoredStateScanOptionsKey] as? [String: AnyObject]
+        let scanOptions = dict[CBCentralManagerRestoredStateScanOptionsKey] as? [String : Any]
         willRestoreState(injectablePeripherals, scannedServices: scannedServices, scanOptions: scanOptions)
     }
 
@@ -345,7 +345,7 @@ public class CentralManager : NSObject, CBCentralManagerDelegate {
 
 
 
-    func willRestoreState(_ cbPeripherals: [CBPeripheralInjectable]?, scannedServices: [CBUUID]?, scanOptions: [String: AnyObject]?) {
+    func willRestoreState(_ cbPeripherals: [CBPeripheralInjectable]?, scannedServices: [CBUUID]?, scanOptions: [String: Any]?) {
         Logger.debug("'\(name)'")
         if let cbPeripherals = cbPeripherals {
             cbPeripherals.forEach { cbPeripheral in

--- a/BlueCapKit/Central/CentralManager.swift
+++ b/BlueCapKit/Central/CentralManager.swift
@@ -348,9 +348,6 @@ public class CentralManager : NSObject, CBCentralManagerDelegate {
     func willRestoreState(_ cbPeripherals: [CBPeripheralInjectable]?, scannedServices: [CBUUID]?, scanOptions: [String: AnyObject]?) {
         Logger.debug("'\(name)'")
         if let cbPeripherals = cbPeripherals {
-            if let options = scanOptions {
-                self.options = options
-            }
             cbPeripherals.forEach { cbPeripheral in
                 let peripheral = Peripheral(cbPeripheral: cbPeripheral, centralManager: self)
                 _discoveredPeripherals[cbPeripheral.identifier] = peripheral
@@ -391,4 +388,5 @@ public class CentralManager : NSObject, CBCentralManagerDelegate {
     }
 
 }
+
 

--- a/Tests/BlueCapKitTests.xcodeproj/project.pbxproj
+++ b/Tests/BlueCapKitTests.xcodeproj/project.pbxproj
@@ -246,7 +246,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		48093224D2110E96163CEF3F /* [CP] Embed Pods Frameworks */ = {

--- a/Tests/BlueCapKitTests/CentralManagerTests.swift
+++ b/Tests/BlueCapKitTests/CentralManagerTests.swift
@@ -140,7 +140,7 @@ class CentralManagerTests: XCTestCase {
                                                 CBCentralManagerOptionRestoreIdentifierKey: "us.gnos.bluecap.test" as AnyObject]
         let future = centralManager.whenStateRestored()
         centralManager.willRestoreState(testPeripherals.map { $0 as CBPeripheralInjectable },
-                                        scannedServices: testScannedServices, options: testOptions)
+                                        scannedServices: testScannedServices, scanOptions: testOptions)
         XCTAssertFutureSucceeds(future, context: TestContext.immediate) {
             guard let options = centralManager.options else {
                 XCTFail()
@@ -175,7 +175,7 @@ class CentralManagerTests: XCTestCase {
         let mock = CBCentralManagerMock()
         let centralManager = CentralManager(centralManager: mock)
         let future = centralManager.whenStateRestored()
-        centralManager.willRestoreState(nil, scannedServices: nil, options: nil)
+        centralManager.willRestoreState(nil, scannedServices: nil, scanOptions: nil)
         XCTAssertFutureFails(future, context: TestContext.immediate) { error in
                 XCTAssertEqualErrors(error, CentralManagerError.restoreFailed)
         }

--- a/Tests/BlueCapKitTests/CentralManagerTests.swift
+++ b/Tests/BlueCapKitTests/CentralManagerTests.swift
@@ -136,22 +136,15 @@ class CentralManagerTests: XCTestCase {
             }
             testPeripheral.services = testServices
         }
-        let testOptions: [String: AnyObject] = [CBCentralManagerOptionShowPowerAlertKey: NSNumber(value: true),
-                                                CBCentralManagerOptionRestoreIdentifierKey: "us.gnos.bluecap.test" as AnyObject]
+
         let future = centralManager.whenStateRestored()
         centralManager.willRestoreState(testPeripherals.map { $0 as CBPeripheralInjectable },
-                                        scannedServices: testScannedServices, scanOptions: testOptions)
+                                        scannedServices: testScannedServices, scanOptions: nil)
         XCTAssertFutureSucceeds(future, context: TestContext.immediate) {
-            guard let options = centralManager.options else {
-                XCTFail()
-                return
-            }
             let peripherals = centralManager.peripherals
             let scannedServices = centralManager.services.map { $0.uuid }
             XCTAssertEqual(peripherals.count, testPeripherals.count)
             XCTAssertEqual(Set(scannedServices), Set(testScannedServices))
-            XCTAssertEqual(options[CBCentralManagerOptionShowPowerAlertKey]! as? NSNumber, testOptions[CBCentralManagerOptionShowPowerAlertKey]! as? NSNumber)
-            XCTAssertEqual(options[CBCentralManagerOptionRestoreIdentifierKey]! as? NSString, testOptions[CBCentralManagerOptionRestoreIdentifierKey]! as? NSString)
             XCTAssertEqual(Set(peripherals.map { $0.identifier }), Set(testPeripherals.map { $0.identifier }))
             for testPeripheral in testPeripherals {
                 let peripheral = centralManager.discoveredPeripherals[testPeripheral.identifier]


### PR DESCRIPTION
Fixes a case where Bluetooth restoration would fail if no scanning options were specified for that central. Setting the CentralManager's options property from the options in willRestoreState was removed because the options given in that method pertains to `CBCentralManagerRestoredStateScanOptionsKey` and not CBCentralManager options. The parameter names have been modified to reflect this.